### PR TITLE
test: Remove subTest usage

### DIFF
--- a/src/tests/integration/blueprints/documents/test_documents_delete.py
+++ b/src/tests/integration/blueprints/documents/test_documents_delete.py
@@ -30,7 +30,6 @@ class DeleteDocumentEndpointTest(_BaseDocumentEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.delete(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.delete(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/documents/test_documents_get.py
+++ b/src/tests/integration/blueprints/documents/test_documents_get.py
@@ -37,21 +37,19 @@ class GetDocumentEndpointTest(_BaseDocumentEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.get(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.get(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )
 
     def test_get_document_file_content_endpoint(self):
         test_cases = ['as_attachment=1', 'as_attachment=0', '']
 
         for test_case in test_cases:
-            with self.subTest(test_case):
-                response = self.client.get(
-                    f'{self.endpoint}?{test_case}',
-                    headers=self.build_headers(
-                        extra_headers={'Content-Type': 'application/json', 'Accept': 'application/octet-stream'}
-                    ),
-                )
+            response = self.client.get(
+                f'{self.endpoint}?{test_case}',
+                headers=self.build_headers(
+                    extra_headers={'Content-Type': 'application/json', 'Accept': 'application/octet-stream'}
+                ),
+            )
 
-                self.assertTrue(isinstance(response.get_data(), bytes))
+            self.assertTrue(isinstance(response.get_data(), bytes))

--- a/src/tests/integration/blueprints/documents/test_documents_save.py
+++ b/src/tests/integration/blueprints/documents/test_documents_save.py
@@ -43,7 +43,6 @@ class GetDocumentEndpointTest(_BaseDocumentEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.base_path, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.base_path, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/documents/test_documents_search.py
+++ b/src/tests/integration/blueprints/documents/test_documents_search.py
@@ -51,7 +51,6 @@ class SearchDocumentEndpointTest(_BaseDocumentEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/documents/test_documents_update.py
+++ b/src/tests/integration/blueprints/documents/test_documents_update.py
@@ -50,7 +50,6 @@ class UpdateDocumentEndpointTest(_BaseDocumentEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.put(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.put(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/roles/test_roles_delete.py
+++ b/src/tests/integration/blueprints/roles/test_roles_delete.py
@@ -25,7 +25,6 @@ class DeleteRoleEndpointTest(_BaseRoleEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.delete(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.delete(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/roles/test_roles_get.py
+++ b/src/tests/integration/blueprints/roles/test_roles_get.py
@@ -29,7 +29,6 @@ class GetRoleEndpointTest(_BaseRoleEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.get(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.get(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/roles/test_roles_save.py
+++ b/src/tests/integration/blueprints/roles/test_roles_save.py
@@ -26,10 +26,9 @@ class SaveRoleEndpointTest(_BaseRoleEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    f'{self.base_path}',
-                    json={},
-                    headers=self.build_headers(user_email=user_email),
-                    exp_code=response_status,
-                )
+            self.client.post(
+                f'{self.base_path}',
+                json={},
+                headers=self.build_headers(user_email=user_email),
+                exp_code=response_status,
+            )

--- a/src/tests/integration/blueprints/roles/test_roles_search.py
+++ b/src/tests/integration/blueprints/roles/test_roles_search.py
@@ -45,10 +45,9 @@ class SearchRoleEndpointTest(_BaseRoleEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                response = self.client.post(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
-                json_response = response.get_json()
+            response = self.client.post(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )
+            json_response = response.get_json()
 
-                self.assertEqual(response_status, response.status_code, json_response)
+            self.assertEqual(response_status, response.status_code, json_response)

--- a/src/tests/integration/blueprints/roles/test_roles_update.py
+++ b/src/tests/integration/blueprints/roles/test_roles_update.py
@@ -32,7 +32,6 @@ class UpdateRoleEndpointTest(_BaseRoleEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.put(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.put(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/test_tasks.py
+++ b/src/tests/integration/blueprints/test_tasks.py
@@ -73,11 +73,10 @@ class TaskEndpointTest(BaseApiTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                response = self.client.get(
-                    f'{self.base_path}/status/{uuid.uuid4()}',
-                    json={},
-                    headers=self.build_headers(),
-                    exp_code=response_status,
-                )
-                self.assertEqual(response.status_code, response_status)
+            response = self.client.get(
+                f'{self.base_path}/status/{uuid.uuid4()}',
+                json={},
+                headers=self.build_headers(user_email=user_email),
+                exp_code=response_status,
+            )
+            self.assertEqual(response.status_code, response_status)

--- a/src/tests/integration/blueprints/users/test_users_delete.py
+++ b/src/tests/integration/blueprints/users/test_users_delete.py
@@ -30,7 +30,6 @@ class DeleteUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.delete(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.delete(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/users/test_users_excel.py
+++ b/src/tests/integration/blueprints/users/test_users_excel.py
@@ -15,12 +15,11 @@ class WordUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for uri, auth_headers, payload in test_cases:
-            with self.subTest(uri=uri):
-                response = self.client.post(uri, json=payload, headers=auth_headers, exp_code=202)
-                json_response = response.get_json()
+            response = self.client.post(uri, json=payload, headers=auth_headers, exp_code=202)
+            json_response = response.get_json()
 
-                self.assertTrue(json_response.get('task'))
-                self.assertTrue(json_response.get('url'))
+            self.assertTrue(json_response.get('task'))
+            self.assertTrue(json_response.get('url'))
 
     def test_check_user_roles_in_export_word_endpoint(self):
         test_cases = [
@@ -30,10 +29,9 @@ class WordUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    f'{self.base_path}/word',
-                    json={},
-                    headers=self.build_headers(user_email=user_email),
-                    exp_code=response_status,
-                )
+            self.client.post(
+                f'{self.base_path}/word',
+                json={},
+                headers=self.build_headers(user_email=user_email),
+                exp_code=response_status,
+            )

--- a/src/tests/integration/blueprints/users/test_users_get.py
+++ b/src/tests/integration/blueprints/users/test_users_get.py
@@ -39,7 +39,6 @@ class GetUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.get(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.get(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/users/test_users_save.py
+++ b/src/tests/integration/blueprints/users/test_users_save.py
@@ -46,10 +46,9 @@ class SaveUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.base_path, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.base_path, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )
 
     def test_create_invalid_user_endpoint(self):
         payload = {

--- a/src/tests/integration/blueprints/users/test_users_search.py
+++ b/src/tests/integration/blueprints/users/test_users_search.py
@@ -49,7 +49,6 @@ class SearchUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/users/test_users_update.py
+++ b/src/tests/integration/blueprints/users/test_users_update.py
@@ -47,7 +47,6 @@ class UpdateUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.put(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.put(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/users/test_users_word.py
+++ b/src/tests/integration/blueprints/users/test_users_word.py
@@ -21,7 +21,6 @@ class ExcelUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/blueprints/users/test_users_word_and_excel.py
+++ b/src/tests/integration/blueprints/users/test_users_word_and_excel.py
@@ -19,7 +19,6 @@ class WordAndExcelUserEndpointTest(_BaseUserEndpointsTest):
         ]
 
         for user_email, response_status in test_cases:
-            with self.subTest(user_email=user_email):
-                self.client.post(
-                    self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
-                )
+            self.client.post(
+                self.endpoint, json={}, headers=self.build_headers(user_email=user_email), exp_code=response_status
+            )

--- a/src/tests/integration/helpers/test_sqlalchemy_query_builder.py
+++ b/src/tests/integration/helpers/test_sqlalchemy_query_builder.py
@@ -46,13 +46,12 @@ class OrderByClauseBuilderTest(BaseTest):
         ]
 
         for sorting, field_name, expected_record in test_cases:
-            with self.subTest(msg=sorting):
-                order = rqo.OrderByClauseBuilder.build_order_by(
-                    Document, request_data={'order': [{'sorting': sorting, 'field_name': field_name}]}
-                )
-                query = db.session.query(Document).order_by(*order)
+            order = rqo.OrderByClauseBuilder.build_order_by(
+                Document, request_data={'order': [{'sorting': sorting, 'field_name': field_name}]}
+            )
+            query = db.session.query(Document).order_by(*order)
 
-                self.assertEqual(query.first().name, expected_record)
+            self.assertEqual(query.first().name, expected_record)
 
     def test_ordering_with_more_than_one_criteria(self):
         with freeze_time('2020-01-01'):
@@ -67,11 +66,10 @@ class OrderByClauseBuilderTest(BaseTest):
         ]
 
         for sorting, expected_record in test_cases:
-            with self.subTest(msg=sorting):
-                order = rqo.OrderByClauseBuilder.build_order_by(Document, request_data={'order': sorting})
-                query = db.session.query(Document).order_by(*order)
+            order = rqo.OrderByClauseBuilder.build_order_by(Document, request_data={'order': sorting})
+            query = db.session.query(Document).order_by(*order)
 
-                self.assertEqual(query.first().name, expected_record)
+            self.assertEqual(query.first().name, expected_record)
 
 
 class StringQueryClauseBuilderTest(BaseTest):
@@ -101,18 +99,13 @@ class StringQueryClauseBuilderTest(BaseTest):
 
         for str_operator, test_case, expected, expected_clauses in test_cases:
             field, field_operator, field_value = test_case
-            with self.subTest(msg=str_operator):
-                sql_clause = self.string_clause_helper.build_clause_with_multiple_values(
-                    field, field_operator, field_value
-                )
-                self.assertEqual(sql_clause.operator, expected.operator)
-                if str_operator == 'multiple values':
-                    for index, _ in enumerate(sql_clause.clauses):
-                        self.assertEqual(
-                            sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator
-                        )
-                else:
-                    self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
+            sql_clause = self.string_clause_helper.build_clause_with_multiple_values(field, field_operator, field_value)
+            self.assertEqual(sql_clause.operator, expected.operator)
+            if str_operator == 'multiple values':
+                for index, _ in enumerate(sql_clause.clauses):
+                    self.assertEqual(sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator)
+            else:
+                self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
 
 
 class ComparisonClauseBuilderTest(BaseTest):
@@ -204,23 +197,18 @@ class ComparisonClauseBuilderTest(BaseTest):
 
         for str_operator, test_case, expected, expected_clauses in test_cases:
             field, field_operator, field_value = test_case
-            with self.subTest(msg=str_operator):
-                sql_clause = self.operator_clause_helper.build_clause_with_multiple_values(
-                    field, field_operator, field_value
-                )
-                self.assertEqual(sql_clause.operator, expected.operator)
-                if str_operator == 'multiple values':
-                    for index, _ in enumerate(sql_clause.clauses):
-                        self.assertEqual(
-                            sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator
-                        )
-                elif str_operator == 'between':
-                    for index, _ in enumerate(sql_clause.right.clauses):
-                        self.assertEqual(
-                            sql_clause.right.clauses[index].value, expected_clauses[index], msg=str_operator
-                        )
-                else:
-                    self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
+            sql_clause = self.operator_clause_helper.build_clause_with_multiple_values(
+                field, field_operator, field_value
+            )
+            self.assertEqual(sql_clause.operator, expected.operator)
+            if str_operator == 'multiple values':
+                for index, _ in enumerate(sql_clause.clauses):
+                    self.assertEqual(sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator)
+            elif str_operator == 'between':
+                for index, _ in enumerate(sql_clause.right.clauses):
+                    self.assertEqual(sql_clause.right.clauses[index].value, expected_clauses[index], msg=str_operator)
+            else:
+                self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
 
     def test_create_search_query_integer(self):
         doc = DocumentFactory(name='Invoice 2024-01', size=1_000_000)
@@ -294,23 +282,18 @@ class ComparisonClauseBuilderTest(BaseTest):
 
         for str_operator, test_case, expected, expected_clauses in test_cases:
             field, field_operator, field_value = test_case
-            with self.subTest(msg=str_operator):
-                sql_clause = self.operator_clause_helper.build_clause_with_multiple_values(
-                    field, field_operator, field_value
-                )
-                self.assertEqual(sql_clause.operator, expected.operator)
-                if str_operator == 'multiple values':
-                    for index, _ in enumerate(sql_clause.clauses):
-                        self.assertEqual(
-                            sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator
-                        )
-                elif str_operator == 'between':
-                    for index, _ in enumerate(sql_clause.right.clauses):
-                        self.assertEqual(
-                            sql_clause.right.clauses[index].value, expected_clauses[index], msg=str_operator
-                        )
-                else:
-                    self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
+            sql_clause = self.operator_clause_helper.build_clause_with_multiple_values(
+                field, field_operator, field_value
+            )
+            self.assertEqual(sql_clause.operator, expected.operator)
+            if str_operator == 'multiple values':
+                for index, _ in enumerate(sql_clause.clauses):
+                    self.assertEqual(sql_clause.clauses[index].right.value, expected_clauses[index], msg=str_operator)
+            elif str_operator == 'between':
+                for index, _ in enumerate(sql_clause.right.clauses):
+                    self.assertEqual(sql_clause.right.clauses[index].value, expected_clauses[index], msg=str_operator)
+            else:
+                self.assertEqual(sql_clause.right.value, expected.right.value, msg=str_operator)
 
 
 class SQLAlchemyQueryBuilderStringsTest(BaseTest, _TestBaseCreateSearchQuery):
@@ -344,9 +327,8 @@ class SQLAlchemyQueryBuilderStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)
 
     def test_create_search_query_text(self):
         software_engineer_description = 'Designs, develops, and maintains software applications.'
@@ -382,9 +364,8 @@ class SQLAlchemyQueryBuilderStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(Role, db.session.query(Role.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(Role, db.session.query(Role.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)
 
     def test_create_search_query_uuid(self):
         user = UserFactory()
@@ -397,9 +378,8 @@ class SQLAlchemyQueryBuilderStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)
 
 
 class SQLAlchemyQueryBuilderNoStringsTest(BaseTest, _TestBaseCreateSearchQuery):
@@ -480,9 +460,8 @@ class SQLAlchemyQueryBuilderNoStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(Document, db.session.query(Document.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(Document, db.session.query(Document.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)
 
     def test_create_search_query_date(self):
         with freeze_time('2020-01-01'):
@@ -548,9 +527,8 @@ class SQLAlchemyQueryBuilderNoStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(User, db.session.query(User.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)
 
     def test_create_search_query_integer(self):
         doc = DocumentFactory(name='Invoice 2024-01', size=1_000_000)
@@ -596,6 +574,5 @@ class SQLAlchemyQueryBuilderNoStringsTest(BaseTest, _TestBaseCreateSearchQuery):
         )
 
         for str_operator, test_case, expected in test_cases:
-            with self.subTest(msg=str_operator):
-                query = self.rqo.create_search_query(Document, db.session.query(Document.id), test_case)
-                self.assertEqual(self._get_values(query), expected, msg=str_operator)
+            query = self.rqo.create_search_query(Document, db.session.query(Document.id), test_case)
+            self.assertEqual(self._get_values(query), expected, msg=str_operator)

--- a/src/tests/integration/repositories/test_document.py
+++ b/src/tests/integration/repositories/test_document.py
@@ -54,11 +54,10 @@ class DocumentRepositoryTest(BaseTest):
         ]
 
         for description, args, kwargs in test_cases:
-            with self.subTest():
-                result = self.repository.find(*args, **kwargs)
-                self.assertIsNotNone(result, (description, args, kwargs))
-                self.assertTrue(isinstance(result, Document), (description, args, kwargs))
-                self.assertEqual(result.id, document.id, (description, args, kwargs))
+            result = self.repository.find(*args, **kwargs)
+            self.assertIsNotNone(result, (description, args, kwargs))
+            self.assertTrue(isinstance(result, Document), (description, args, kwargs))
+            self.assertEqual(result.id, document.id, (description, args, kwargs))
 
     def test_delete_soft_document(self):
         user = UserFactory()

--- a/src/tests/integration/repositories/test_role.py
+++ b/src/tests/integration/repositories/test_role.py
@@ -43,11 +43,10 @@ class RoleRepositoryTest(BaseTest):
         ]
 
         for description, args, kwargs in test_cases:
-            with self.subTest():
-                result = self.repository.find(*args, **kwargs)
-                self.assertIsNotNone(result, (description, args, kwargs))
-                self.assertTrue(isinstance(result, Role), (description, args, kwargs))
-                self.assertEqual(result.id, role.id, (description, args, kwargs))
+            result = self.repository.find(*args, **kwargs)
+            self.assertIsNotNone(result, (description, args, kwargs))
+            self.assertTrue(isinstance(result, Role), (description, args, kwargs))
+            self.assertEqual(result.id, role.id, (description, args, kwargs))
 
     def test_find_by_name_role(self):
         role = RoleFactory(deleted_at=None)

--- a/src/tests/integration/repositories/test_user.py
+++ b/src/tests/integration/repositories/test_user.py
@@ -48,11 +48,10 @@ class UserRepositoryTest(BaseTest):
         ]
 
         for description, args, kwargs in test_cases:
-            with self.subTest():
-                result = self.repository.find(*args, **kwargs)
-                self.assertIsNotNone(result, (description, args, kwargs))
-                self.assertTrue(isinstance(result, User), (description, args, kwargs))
-                self.assertEqual(result.id, user.id, (description, args, kwargs))
+            result = self.repository.find(*args, **kwargs)
+            self.assertIsNotNone(result, (description, args, kwargs))
+            self.assertTrue(isinstance(result, User), (description, args, kwargs))
+            self.assertEqual(result.id, user.id, (description, args, kwargs))
 
     def test_find_by_email_user(self):
         user = UserFactory(


### PR DESCRIPTION
pytest does not natively support unittest's self.subTest, and subTest blocks do not generate separate test cases or granular reports when running tests with pytest.